### PR TITLE
allow init Migrations in Default Migration Config

### DIFF
--- a/backend/alanda-development/src/main/resources/db-migration/db-migration-default.properties
+++ b/backend/alanda-development/src/main/resources/db-migration/db-migration-default.properties
@@ -4,7 +4,7 @@
 db.local.url=jdbc:oracle:thin:@127.0.0.1:1521:xe
 db.local.user=alanda
 db.local.password=alanda
-db.local.allowInit=false
+db.local.allowInit=true
 db.local.skipUserApproval=true
 
 fs.export=/home/developer/export/


### PR DESCRIPTION
Currently the init command for db migrations is not enabled in the default migration config
For easier project setup this should be enabled