### PR TITLE
Added optional page size select for ProjectMonitorComponent

### DIFF
--- a/frontend/alanda-libraries/projects/alanda-common/src/lib/alanda-common.module.ts
+++ b/frontend/alanda-libraries/projects/alanda-common/src/lib/alanda-common.module.ts
@@ -86,6 +86,7 @@ import { RoleManagementComponent } from './components/admin/role-management/role
 import { PermissionManagementComponent } from './components/admin/permission-management/permission-management.component';
 import { HistoryServiceNg } from './api/history.service';
 import { TreeTableModule } from 'primeng/treetable';
+import { AlandaPagesizeSelectComponent } from './components/pagesize-select/pagesize-select.component';
 
 @NgModule({
   imports: [
@@ -158,7 +159,8 @@ import { TreeTableModule } from 'primeng/treetable';
     DropdownSelectComponent,
     SelectMilestoneComponent,
     AlandaTaskTemplateComponent,
-    ProjectAndProcessesComponent
+    ProjectAndProcessesComponent,
+    AlandaPagesizeSelectComponent
   ],
   exports: [
     ProjectMonitorComponent,

--- a/frontend/alanda-libraries/projects/alanda-common/src/lib/components/pagesize-select/pagesize-select.component.ts
+++ b/frontend/alanda-libraries/projects/alanda-common/src/lib/components/pagesize-select/pagesize-select.component.ts
@@ -1,0 +1,88 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  SimpleChanges,
+  ViewChild,
+} from '@angular/core';
+import { SelectItem } from 'primeng/api';
+import { Subject } from 'rxjs';
+import { debounceTime, takeUntil } from 'rxjs/operators';
+import { Dropdown } from 'primeng/dropdown';
+
+@Component({
+  selector: 'al-pagesize-select',
+  template: `
+    <p-dropdown #dropdown [placeholder]="defaultPageSize.toString()" editable="true" [options]="pageSizeOptions"
+                (onChange)="selectedPageSize.next($event.value)" showTransitionOptions="0ms" hideTransitionOptions="0ms"></p-dropdown>`,
+  styles: [`
+    p-dropdown ::ng-deep .ui-inputtext {
+      padding-top: 2px;
+      padding-bottom: 2px;
+    }
+
+    p-dropdown ::ng-deep .ui-dropdown {
+      height: unset;
+    }
+  `],
+})
+export class AlandaPagesizeSelectComponent implements OnInit, OnChanges, OnDestroy {
+  static defaultPageSizes = [15, 75, 250, 1000, 5000];
+
+  private unsubscribe$ = new Subject<void>();
+  selectedPageSize = new Subject<number>();
+
+  @Output() onChange = new EventEmitter<number>();
+
+  @Input() pageSizes: number[] = AlandaPagesizeSelectComponent.defaultPageSizes;
+  @Input() maxPageSize: number;
+  @Input() defaultPageSize: number = 15;
+  pageSizeOptions: SelectItem[] = this.trimPageSizes();
+
+  @ViewChild('dropdown') dropdown: Dropdown;
+
+  ngOnInit(): void {
+    this.selectedPageSize.pipe(
+      takeUntil(this.unsubscribe$),
+      debounceTime(750),
+    ).subscribe(pageSize => this.onChange.emit(pageSize));
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['pageSizes'] || changes['maxPageSize'] || changes['initialPageSize']) {
+      this.pageSizeOptions = this.trimPageSizes();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
+  }
+
+  setPageSize(pageSize: number) {
+    this.dropdown.selectItem(undefined, {label: pageSize, value: pageSize});
+  }
+
+  private trimPageSizes(): SelectItem[] {
+    let sizes: number[];
+
+    if (this.maxPageSize === undefined) {
+      sizes = [...this.pageSizes];
+    } else {
+      sizes = [...this.pageSizes.filter(ps => ps < this.maxPageSize), this.maxPageSize];
+    }
+
+    if (sizes.indexOf(this.defaultPageSize) === -1) {
+      sizes.push(this.defaultPageSize);
+    }
+
+    return sizes.sort((a, b) => a - b)
+      .map(p => {
+        return {label: p.toString(), value: p};
+      });
+  }
+}

--- a/frontend/alanda-libraries/projects/alanda-common/src/lib/components/project-monitor/project-monitor.component.html
+++ b/frontend/alanda-libraries/projects/alanda-common/src/lib/components/project-monitor/project-monitor.component.html
@@ -32,14 +32,14 @@
                 <p-table #tt
                   [style]="{'min-height':'500px'}"
                   [resizableColumns]="true"
-                  [value]="projectsData.results" 
+                  [value]="projectsData.results"
                   [columns]="selectedLayout.columnDefs"
-                  [paginator]="true" 
-                  [rows]="15" 
+                  [paginator]="true"
+                  [rows]="serverOptions.pageSize"
                   [lazy]="true"
                   [totalRecords]="projectsData.total"
                   (onLazyLoad)="loadProjectsLazy($event)"
-                  [tableStyle]="{'table-layout':'100%'}" 
+                  [tableStyle]="{'table-layout':'100%'}"
                   [autoLayout]="true"
                   [loading]="loading"
                   [responsive]="true">
@@ -48,7 +48,7 @@
                       <p-menu #menu [popup]="true" [model]="menuItems" appendTo="body"></p-menu>
                       <button type="button" pButton icon="fa fa-fw fa-list" (click)="menu.toggle($event)" style="float:right; width: 50px"></button>
                     </div>
-                    <!--                     
+                    <!--
                     <div class="ui-helper-clearfix">
                       <button type="button" pButton icon="fa fa-file-o" iconPos="left" label="Export CSV" (click)="tt.exportCSV()" style="float:right; width: 130px"></button>
                     </div> -->
@@ -61,9 +61,9 @@
                     </tr>
                     <tr>
                       <th *ngFor="let col of columns">
-                          <input 
-                            pInputText 
-                            type="text" 
+                          <input
+                            pInputText
+                            type="text"
                             (input)="tt.filter($event.target.value, col.field, 'contains')"
                             [value] ="tt.filters[col.field] ? tt.filters[col.field].value : ''"
                             style="width: 100%"
@@ -73,9 +73,9 @@
                     </tr>
                   </ng-template>
                   <ng-template pTemplate="body" let-project let-columns="columns" >
-                    <tr 
+                    <tr
                       [pSelectableRow]="project"
-                      class="ng-center-cell">  
+                      class="ng-center-cell">
                       <td *ngFor="let col of columns" [ngClass]="getCondition(project, col.template)" style="font-size: 12px; white-space: nowrap;">
                         <ng-template [ngIf]="col.name == 'Project ID'" [ngIfElse]="default">
                           <!-- <a [attr.href]="'#/pmc/projectdetails/' + project.project.projectId" target="blank">{{ project | monitorValues: col.field }}</a> -->
@@ -85,11 +85,17 @@
                           {{ project | monitorValues: col.field }}
                         </ng-template>
                       </td>
-                    </tr>  
+                    </tr>
                   </ng-template>
                   <ng-template pTemplate="paginatorright">
+                    <span *ngIf="editablePageSize" style="margin-right: 10px">
+                      Rows per page:
+                      <al-pagesize-select #pageSizeSelect (onChange)="changePageSize($event)" [maxPageSize]="projectsData.total"></al-pagesize-select>
+                    </span>
                     <span *ngIf="projectsData.total">
-                      Total: {{projectsData.total}}
+                      Total:
+                      <ng-container *ngIf="!editablePageSize; else settableTotal">{{projectsData.total}}</ng-container>
+                      <ng-template #settableTotal><a (click)="pageSizeSelect.setPageSize(projectsData.total)">{{projectsData.total}}</a></ng-template>
                     </span>
                   </ng-template>
                 </p-table>

--- a/frontend/alanda-libraries/projects/alanda-common/src/lib/components/project-monitor/project-monitor.component.ts
+++ b/frontend/alanda-libraries/projects/alanda-common/src/lib/components/project-monitor/project-monitor.component.ts
@@ -3,8 +3,9 @@ import { LazyLoadEvent, MenuItem, MessageService } from 'primeng/api';
 import { Table } from 'primeng/table';
 import { ProjectServiceNg } from '../../api/project.service';
 import { TableAPIServiceNg } from '../../services/tableAPI.service';
+import { AlandaPagesizeSelectComponent } from '../pagesize-select/pagesize-select.component';
 export type ServerOptions = {
-  pageNumber: number, 
+  pageNumber: number,
   pageSize: number,
   filterOptions: any,
   sortOptions: any
@@ -18,6 +19,7 @@ export type ServerOptions = {
 export class ProjectMonitorComponent implements OnInit {
 
   @Input() defaultLayout : string;
+  @Input() editablePageSize: boolean = false;
 
   projectsData: any = {};
   layouts: any[] = [];
@@ -28,7 +30,8 @@ export class ProjectMonitorComponent implements OnInit {
   menuItems: MenuItem[];
 
   @ViewChild('tt') turboTable: Table;
- 
+  @ViewChild('pageSizeSelect') pageSizeSelect: AlandaPagesizeSelectComponent;
+
   constructor(private projectService: ProjectServiceNg, private tableAPIServiceNg: TableAPIServiceNg, public messageService: MessageService) {
     this.serverOptions = {
       pageNumber: 1,
@@ -47,7 +50,7 @@ export class ProjectMonitorComponent implements OnInit {
     const data = this.tableAPIServiceNg.getProjectMonitorLayouts();
     for(const k in data) {
       this.layouts.push(data[k]);
-    }    
+    }
     this.layouts.sort((a, b) => a.displayName.localeCompare(b.displayName));
 
     this.selectedLayout = this.layouts.filter(layout => layout.name === 'all')[0];
@@ -60,7 +63,7 @@ export class ProjectMonitorComponent implements OnInit {
         this.projectsData = res;
         this.loading = false;
       }
-    ); 
+    );
   }
 
   loadProjectsLazy(event: LazyLoadEvent){
@@ -75,11 +78,11 @@ export class ProjectMonitorComponent implements OnInit {
     this.serverOptions.filterOptions = {};
     for(let key of Object.keys(this.selectedLayout.filterOptions)){
       this.serverOptions.filterOptions[key] = this.selectedLayout.filterOptions[key];
-    }    
+    }
     for(let key in event.filters){
       this.serverOptions.filterOptions[key] = event.filters[key].value;
     }
-    
+
     this.serverOptions.pageNumber = event.first / this.serverOptions.pageSize + 1;
     this.loadProjects(this.serverOptions);
   }
@@ -104,4 +107,17 @@ export class ProjectMonitorComponent implements OnInit {
     return '/projectdetails/' + projectId;
   }
 
+  changePageSize(pageSize: number) {
+    console.log('Page size changed', pageSize);
+    const oldPageSize = this.serverOptions.pageSize;
+    const oldPageNumber = this.serverOptions.pageNumber;
+
+    // first entry should be visible after changing rows per page
+    const firstEntry = oldPageSize * (oldPageNumber - 1) + 1;
+
+    this.serverOptions.pageSize = pageSize;
+    this.serverOptions.pageNumber = Math.ceil(firstEntry / pageSize);
+
+    this.loadProjects(this.serverOptions);
+  }
 }


### PR DESCRIPTION
- added input property 'editablePageSize' to ProjectMonitorComponent
- if true, rows per page can be input either via dropdown, keyboard or click on total result number
- displaying many or all rows / projects (>1000) may have adverse effects (ie. wreck your browser performance-wise)

Per default, property editablePageSize is set to false and page size dropdown isn't displayed, so current monitor behaviour shouldn't be affected.