### PR TITLE
fix(H3ASUPP-2333) added startProcessNode to PaP, when it is automatic…

### DIFF
--- a/frontend/alanda/libs/common/src/lib/components/project-and-processes/project-and-processes.component.ts
+++ b/frontend/alanda/libs/common/src/lib/components/project-and-processes/project-and-processes.component.ts
@@ -455,10 +455,6 @@ export class AlandaProjectAndProcessesComponent implements OnDestroy {
           finalize(() => (this.loading = false)),
         )
         .subscribe((tree) => {
-          node.children = tree?.children;
-          node.children.push(
-            this.papService.getStartProcessDropdownAsTreeNode(data.project),
-          );
           this.data = [...this.data];
         });
     }

--- a/frontend/alanda/libs/common/src/lib/components/project-and-processes/project-and-processes.service.ts
+++ b/frontend/alanda/libs/common/src/lib/components/project-and-processes/project-and-processes.service.ts
@@ -147,6 +147,7 @@ export class AlandaProjectAndProcessesService {
         }
       }
     });
+    children.push(this.getStartProcessDropdownAsTreeNode(project));
 
     return {
       key: id,


### PR DESCRIPTION
…ally expanded

# Description

The 'Start Process' Dropdown is not displayed currently, if the Projects and Processes Component is expanded automatically. 
This is fixed, if the Project is collapsed and expanded again.

## Jira Ticket
https://jira.bpmasters.at/jira/browse/H3ASUPP-2333

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)