### PR TITLE
fix(H3ASUPP-2333) Processes are now correctly added to the tree when PaP are automatically expanded

### DIFF
--- a/backend/alanda-rest-impl/src/main/java/io/alanda/rest/impl/PmcMilestoneRestServiceImpl.java
+++ b/backend/alanda-rest-impl/src/main/java/io/alanda/rest/impl/PmcMilestoneRestServiceImpl.java
@@ -131,7 +131,7 @@ public class PmcMilestoneRestServiceImpl implements PmcMilestoneRestService {
     if (actHasChanged || Boolean.TRUE.equals(delAct)) {
       checkPermissionsForMilestone(p.getGuid(), msIdName, ":act", "write");
     }
-    pmcProjectService.updateProjectMilestone(projectId, msIdName, fc, act, reason, delFc, delAct);
+    pmcProjectService.updateProjectMilestone(p.getGuid(), msIdName, fc, delFc, act, delAct, reason);
     return Response.ok().build();
   }
 

--- a/frontend/alanda/libs/common/package-lock.json
+++ b/frontend/alanda/libs/common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alanda/common",
-  "version": "10.0.258",
+  "version": "10.0.259-pro",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/frontend/alanda/libs/common/package.json
+++ b/frontend/alanda/libs/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alanda/common",
-  "version": "10.0.258",
+  "version": "10.0.259-pro",
   "peerDependencies": {
     "@angular/animations": "^10.1.0",
     "@angular/common": "^10.1.0",

--- a/frontend/alanda/libs/common/src/lib/components/project-and-processes/project-and-processes.component.ts
+++ b/frontend/alanda/libs/common/src/lib/components/project-and-processes/project-and-processes.component.ts
@@ -455,10 +455,6 @@ export class AlandaProjectAndProcessesComponent implements OnDestroy {
           finalize(() => (this.loading = false)),
         )
         .subscribe((tree) => {
-          node.children = tree?.children;
-          node.children.push(
-            this.papService.getStartProcessDropdownAsTreeNode(data.project),
-          );
           this.data = [...this.data];
         });
     }

--- a/frontend/alanda/libs/common/src/lib/components/project-and-processes/project-and-processes.component.ts
+++ b/frontend/alanda/libs/common/src/lib/components/project-and-processes/project-and-processes.component.ts
@@ -455,6 +455,7 @@ export class AlandaProjectAndProcessesComponent implements OnDestroy {
           finalize(() => (this.loading = false)),
         )
         .subscribe((tree) => {
+          node.children = tree?.children;
           this.data = [...this.data];
         });
     }

--- a/frontend/alanda/libs/common/src/lib/components/project-and-processes/project-and-processes.service.ts
+++ b/frontend/alanda/libs/common/src/lib/components/project-and-processes/project-and-processes.service.ts
@@ -147,6 +147,7 @@ export class AlandaProjectAndProcessesService {
         }
       }
     });
+    children.push(this.getStartProcessDropdownAsTreeNode(project));
 
     return {
       key: id,


### PR DESCRIPTION
# Description
With the previous fix, there was a bug which prevented a new Process from being added and viewed correctly. When creating a new Process, there would be no new Dropdown for creating another one.

## Jira Ticket
https://jira.bpmasters.at/jira/browse/H3ASUPP-2333

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

