### PR TITLE
feat() Delegate Task Dialog is now shown immediately, to make button …

### DIFF
--- a/frontend/alanda/libs/common/package-lock.json
+++ b/frontend/alanda/libs/common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alanda/common",
-  "version": "10.0.260",
+  "version": "10.0.261-pro",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/frontend/alanda/libs/common/package-lock.json
+++ b/frontend/alanda/libs/common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alanda/common",
-  "version": "10.0.261-pro",
+  "version": "10.0.261-pro-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/frontend/alanda/libs/common/package.json
+++ b/frontend/alanda/libs/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alanda/common",
-  "version": "10.0.261-pro",
+  "version": "10.0.261-pro-2",
   "peerDependencies": {
     "@angular/animations": "^10.1.0",
     "@angular/common": "^10.1.0",

--- a/frontend/alanda/libs/common/package.json
+++ b/frontend/alanda/libs/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alanda/common",
-  "version": "10.0.260",
+  "version": "10.0.261-pro",
   "peerDependencies": {
     "@angular/animations": "^10.1.0",
     "@angular/common": "^10.1.0",

--- a/frontend/alanda/libs/common/src/lib/components/task-table/task-table.component.ts
+++ b/frontend/alanda/libs/common/src/lib/components/task-table/task-table.component.ts
@@ -350,7 +350,6 @@ export class AlandaTaskTableComponent {
           return {
             candidateUsers: response,
             delegatedTaskData: data,
-            showDelegateDialog: true,
           };
         }),
       );

--- a/frontend/alanda/libs/common/src/lib/components/task-table/task-table.component.ts
+++ b/frontend/alanda/libs/common/src/lib/components/task-table/task-table.component.ts
@@ -337,11 +337,11 @@ export class AlandaTaskTableComponent {
   );
 
   delegateTask$ = this.delegateTaskEvent$.pipe(
+    tap(() => {
+      this.state.set({ showDelegateDialog: true });
+    }),
     switchMap((data: AlandaTaskListData) => {
       return this.taskService.getCandidates(data.task.task_id).pipe(
-        tap(() => {
-          this.state.set({ showDelegateDialog: true });
-        }),
         catchError((err, caught) => {
           console.error(err);
           return EMPTY;

--- a/frontend/alanda/libs/common/src/lib/components/task-table/task-table.component.ts
+++ b/frontend/alanda/libs/common/src/lib/components/task-table/task-table.component.ts
@@ -339,6 +339,9 @@ export class AlandaTaskTableComponent {
   delegateTask$ = this.delegateTaskEvent$.pipe(
     switchMap((data: AlandaTaskListData) => {
       return this.taskService.getCandidates(data.task.task_id).pipe(
+        tap(() => {
+          this.state.set({ showDelegateDialog: true });
+        }),
         catchError((err, caught) => {
           console.error(err);
           return EMPTY;


### PR DESCRIPTION
…more responsive

# Description
When pressing the 'Delegate' Button in Tasklist, with many users, there is a significant Delay between Pressing the Button, and getting any kind of feedback, as it is loading the correct users. This Change shows the Dialog immediately to remedy that. 

## Jira Ticket
H3ASUPP-2402

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
